### PR TITLE
Add redis cache

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -2,3 +2,6 @@ services:
   recommendations:
     ports:
       - "8080:8080"
+  redis:
+    ports:
+      - "6379:6379"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,3 +6,15 @@ services:
       - ENV_VAR=example
     volumes:
       - ./app:/app
+  redis:
+    image: "redis:alpine"
+    container_name: redis_cache
+    restart: always
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+volumes:
+  redis_data:
+    driver: local


### PR DESCRIPTION
This pull request includes changes to add a Redis service to the Docker Compose setup. The most important changes include adding Redis service configurations to both `docker-compose.override.yaml` and `docker-compose.yaml`.

Changes to Docker Compose configuration:

* [`docker-compose.override.yaml`](diffhunk://#diff-5cf196bb28f864c2149668ce0fc575489e4446710d79129f3d8cece2639ef6c3R5-R7): Added Redis service with port mapping for `6379:6379`.
* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R9-R20): Added Redis service with image `redis:alpine`, container name `redis_cache`, restart policy `always`, port mapping for `6379:6379`, and volume mapping for `redis_data:/data`. Also defined a new volume `redis_data` with driver `local`.