### PR TITLE
VOYAGE-231-Consume-the-user-invitations-for-group-trips-in-the-frontend

### DIFF
--- a/app/handlers/itinerary_handler.py
+++ b/app/handlers/itinerary_handler.py
@@ -296,9 +296,10 @@ def generate_itinerary(
     start_date: datetime,
     end_date: datetime,
     generic_type_scores: Dict[str, float],
+    is_group: bool,
     template_type: TemplateType = TemplateType.MODERATE,
-    must_visit_places:List[PlaceInfo]=[],
-    budget: float = None,
+    must_visit_places: List[PlaceInfo] = [],
+    budget: float = None
 ) -> TripItinerary:
     """Generate a complete trip itinerary with improved landmark selection"""
 
@@ -416,7 +417,8 @@ def generate_itinerary(
             end_date if current_date > end_date else current_date - timedelta(days=1)
         ),
         days=days,
-        name=""
+        name="",
+        is_group=is_group,
     )
 
 

--- a/app/routes/trip.py
+++ b/app/routes/trip.py
@@ -178,6 +178,7 @@ async def create_trip(trip_data: TripCreate):
             generic_type_scores=generic_type_scores,
             must_visit_places=mvps,
             budget=trip_data.budget,
+            is_group=trip_data.is_group,
         )
         itinerary.name=trip_data.name
         itinerary = api.generate_itinerary(itinerary)
@@ -216,6 +217,7 @@ async def create_trip(trip_data: TripCreate):
             trip_type=trip_type.value,
             template_type=template_type,
             generic_type_scores=generic_type_scores,
+            is_group=trip_data.is_group,
         )
 
         # Cache the trip response

--- a/app/schemas/Activities.py
+++ b/app/schemas/Activities.py
@@ -93,6 +93,7 @@ class TripItinerary(BaseModel):
     end_date: datetime
     days: List[DayItinerary] = []
     name:str
+    is_group: bool
     def __str__(self):
         activies = ""
         for day in self.days:

--- a/app/schemas/Questionnaire.py
+++ b/app/schemas/Questionnaire.py
@@ -5,11 +5,9 @@ from pydantic import BaseModel,Field
 from app.schemas.Activities import PlaceInfo, TripItinerary, TemplateType,RoadItinerary
 from datetime import datetime
 
-
 class QuestionType(str, Enum):
     SCALE = "scale"
     SELECT = "select"
-
 
 class Answer(BaseModel):
     question_id: int
@@ -53,6 +51,7 @@ class TripCreate(BaseModel):
     budget: float
     keywords: List[str] = []
     must_visit_places: Optional[List[PlaceInfo]] = []
+    is_group: bool
 
 class TripResponse(BaseModel):
     itinerary: TripItinerary | RoadItinerary


### PR DESCRIPTION
This pull request introduces a new `is_group` parameter to support group-specific itinerary generation, along with minor cleanup in the `Questionnaire` schema file. The most important changes include adding the `is_group` parameter to relevant models, functions, and API calls, as well as ensuring proper propagation of this parameter throughout the system.

### Group-specific itinerary support:
* [`app/handlers/itinerary_handler.py`](diffhunk://#diff-e44d384ca9b8623fff9aa759e7a7a86f23b34412f038536a3f7adc5bc561383bR299-R302): Updated the `generate_itinerary` function to include the `is_group` parameter and propagate it to the `TripItinerary` object. [[1]](diffhunk://#diff-e44d384ca9b8623fff9aa759e7a7a86f23b34412f038536a3f7adc5bc561383bR299-R302) [[2]](diffhunk://#diff-e44d384ca9b8623fff9aa759e7a7a86f23b34412f038536a3f7adc5bc561383bL419-R421)
* [`app/routes/trip.py`](diffhunk://#diff-554cc8b6c3bccd55105e5059981e82d04a221a310864d39e6840f4f7fd72843bR181): Modified the `get_radius` function to pass the `is_group` parameter from `trip_data` to the `generate_itinerary` API call. [[1]](diffhunk://#diff-554cc8b6c3bccd55105e5059981e82d04a221a310864d39e6840f4f7fd72843bR181) [[2]](diffhunk://#diff-554cc8b6c3bccd55105e5059981e82d04a221a310864d39e6840f4f7fd72843bR220)
* [`app/schemas/Activities.py`](diffhunk://#diff-9153274e077b51ecfad05e74a4850e981a62c6edf0ab521a3da8c8ea510f4669R96): Added the `is_group` attribute to the `TripItinerary` model to store group-specific information.
* [`app/schemas/Questionnaire.py`](diffhunk://#diff-af785b9749a15c211ea9805c817508261224f79e049331f44fe5dfa7ebc52d6bR54): Added the `is_group` attribute to the `TripCreate` schema to capture group-related input during trip creation.

### Minor cleanup:
* [`app/schemas/Questionnaire.py`](diffhunk://#diff-af785b9749a15c211ea9805c817508261224f79e049331f44fe5dfa7ebc52d6bL8-L13): Removed unnecessary blank lines for code readability.