### PR TITLE
Increase the ttl for regeneration of activities

### DIFF
--- a/app/handlers/regenerate_activity_handler.py
+++ b/app/handlers/regenerate_activity_handler.py
@@ -67,7 +67,7 @@ def regenerate_activity_handler(trip_id: str, activity_id: int, places: dict, it
                 category: [place.dict() for place in places]
                 for category, places in places.items()
             }
-            redis_cache.set(f"trip:{trip_id}:pre_ranked_places", json.dumps(places_dict, cls=PydanticJSONEncoder), ttl=86400)
+            redis_cache.set(f"trip:{trip_id}:pre_ranked_places", json.dumps(places_dict, cls=PydanticJSONEncoder), ttl=604800)
 
     current_activity = get_current_activity()
     if not current_activity:

--- a/app/routes/trip.py
+++ b/app/routes/trip.py
@@ -209,7 +209,7 @@ async def create_trip(trip_data: TripCreate):
             category: [place.dict() for place in places]
             for category, places in non_used_pre_ranked_places.items()
         }
-        redis_cache.set(f"trip:{trip_id}:pre_ranked_places", json.dumps(pre_ranked_places_dict), ttl=86400)  # 24 hours
+        redis_cache.set(f"trip:{trip_id}:pre_ranked_places", json.dumps(pre_ranked_places_dict), ttl=604800)  # 7 days
 
         #add price-range to itinerary
         itinerary.price_range=total_range
@@ -247,7 +247,7 @@ async def create_trip(trip_data: TripCreate):
         
         # Convert to dict and save to cache
         trip_dict = trip_response.dict()
-        redis_cache.set(f"trip:{trip_id}:response", json.dumps(trip_dict, cls=PydanticJSONEncoder), ttl=86400)
+        redis_cache.set(f"trip:{trip_id}:response", json.dumps(trip_dict, cls=PydanticJSONEncoder), ttl=604800)
 
         return trip_response
 
@@ -404,7 +404,7 @@ async def regenerate_activity(trip_id: str, activity: dict):
     
     # Convert to dict and save to cache
     trip_dict = trip_response.dict()
-    redis_cache.set(f"trip:{trip_id}:response", json.dumps(trip_dict, cls=PydanticJSONEncoder), ttl=86400)
+    redis_cache.set(f"trip:{trip_id}:response", json.dumps(trip_dict, cls=PydanticJSONEncoder), ttl=604800)
 
     return {
         "response": {
@@ -512,7 +512,7 @@ async def delete_activity(trip_id: str, activity_id: str):
     
     # Convert to dict and save to cache
     trip_dict = trip_response.dict()
-    redis_cache.set(f"trip:{trip_id}:response", json.dumps(trip_dict, cls=PydanticJSONEncoder), ttl=86400)
+    redis_cache.set(f"trip:{trip_id}:response", json.dumps(trip_dict, cls=PydanticJSONEncoder), ttl=604800)
 
     return {
         "response": {


### PR DESCRIPTION
# Pull Request Template

## Title
<!-- Provide a concise and clear title for the PR -->

## Type of Issue
- [x] Bug Fix 🐛  
- [ ] Feature ✨  
- [ ] Improvement 🔧  
- [ ] Documentation 📖  
- [ ] Other (please specify):  

## Description
This pull request updates the caching behavior across multiple functions to extend the time-to-live (TTL) for Redis cache entries from 24 hours (86400 seconds) to 7 days (604800 seconds). These changes ensure that cached data persists longer, reducing the need for frequent recomputation or data fetching.

### Changes to caching TTL:

* `app/handlers/regenerate_activity_handler.py`:
  - Updated the TTL for pre-ranked places in the `update_place_queue` function from 24 hours to 7 days.

* `app/routes/trip.py`:
  - Updated the TTL for pre-ranked places in the `get_radius` function from 24 hours to 7 days.
  - Updated the TTL for trip responses in the `get_radius` function from 24 hours to 7 days.
  - Updated the TTL for trip responses in the `regenerate_activity` function from 24 hours to 7 days.
  - Updated the TTL for trip responses in the `delete_activity` function from 24 hours to 7 days.

