### PR TITLE
fix price-range

### DIFF
--- a/app/handlers/places_handler.py
+++ b/app/handlers/places_handler.py
@@ -262,7 +262,7 @@ async def search_places_by_keyword(
                 price_range=data.get("priceRange") if isinstance(data.get("priceRange"), dict) else {
                     "start_price": 0.0,
                     "end_price": 0.0,
-                    "currency": "USD"
+                    "currency": "EUR"
                 },
                 rating=data.get("rating"),
                 user_ratings_total=data.get("userRatingCount"),

--- a/app/handlers/places_handler.py
+++ b/app/handlers/places_handler.py
@@ -49,7 +49,11 @@ async def get_places_recommendations(
                 photos=data.get("photos", []),
                 accessibility_options=data.get("accessibilityOptions", {}),
                 opening_hours=data.get("OpeningHours", {}),
-                price_range=data.get("priceRange"),
+                price_range=data.get("priceRange") if isinstance(data.get("priceRange"), dict) else {
+                    "start_price": 0.0,
+                    "end_price": 0.0,
+                    "currency": "EUR"
+                },
                 rating=data.get("rating"),
                 user_ratings_total=data.get("userRatingCount"),
                 international_phone_number=data.get("internationalPhoneNumber"),
@@ -255,7 +259,11 @@ async def search_places_by_keyword(
                 photos=data.get("photos", []),
                 accessibility_options=data.get("accessibilityOptions", {}),
                 opening_hours=data.get("OpeningHours", {}),
-                price_range=data.get("priceRange"),
+                price_range=data.get("priceRange") if isinstance(data.get("priceRange"), dict) else {
+                    "start_price": 0.0,
+                    "end_price": 0.0,
+                    "currency": "USD"
+                },
                 rating=data.get("rating"),
                 user_ratings_total=data.get("userRatingCount"),
                 international_phone_number=data.get("internationalPhoneNumber"),


### PR DESCRIPTION
# Pull Request Template

## Title
<!-- Provide a concise and clear title for the PR -->

## Type of Issue
- [x] Bug Fix 🐛  
- [ ] Feature ✨  
- [ ] Improvement 🔧  
- [ ] Documentation 📖  
- [ ] Other (please specify):  

## Description
i guess the price range was not always being properly initialized, i was not able to create a trip without this change
### Changes to `price_range` handling:

* In `async def get_places_recommendations`: Updated the `price_range` field to use default values (`start_price: 0.0`, `end_price: 0.0`, `currency: "EUR"`) if it is not a dictionary.
* In `async def search_places_by_keyword`: Updated the `price_range` field to use default values (`start_price: 0.0`, `end_price: 0.0`, `currency: "USD"`) if it is not a dictionary.
